### PR TITLE
Fix expected error text in assertion

### DIFF
--- a/rure_test.go
+++ b/rure_test.go
@@ -10,7 +10,7 @@ func TestError(t *testing.T) {
 	re, err := Compile(`(`)
 	assert.Nil(t, re)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Unclosed parenthesis")
+	assert.Contains(t, err.Error(), "unclosed group")
 }
 
 func TestIsMatch(t *testing.T) {


### PR DESCRIPTION
It seems that a recent upgrade to librure would have changed the error text when grouping parentheses aren't balanced.

Changing the test below has made the tests pass on my machine with the latest librure